### PR TITLE
Refactor and maybe fix a crash on some player death

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2754,21 +2754,7 @@ void CCharacter::Die(int Killer, int Weapon)
 	GameServer()->m_World.RemoveEntity(this);
 	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
 	GameServer()->CreateDeath(m_Pos, m_pPlayer->GetCID());
-	
-	CPlayer* pKillerPlayer = nullptr;
-	if(Killer >=0 && Killer < MAX_CLIENTS)
-	{
-		pKillerPlayer = GameServer()->m_apPlayers[Killer];
-		if (pKillerPlayer)
-		{
-			pKillerCharacter = pKillerPlayer->GetCharacter();
-		}
-		if(pKillerCharacter && pKillerPlayer->GetClass() == PLAYERCLASS_SNIPER)
-		{
-			GiveWeapon(WEAPON_RIFLE, 1);
-		}
-	}
-	
+
 /* INFECTION MODIFICATION START ***************************************/
 	if(GetClass() == PLAYERCLASS_BOOMER && !IsFrozen() && Weapon != WEAPON_GAME && !(IsInLove() && Weapon == WEAPON_SELF) )
 	{
@@ -2800,20 +2786,28 @@ void CCharacter::Die(int Killer, int Weapon)
 	}
 /* INFECTION MODIFICATION END *****************************************/
 
-	if (pKillerPlayer && (pKillerPlayer != m_pPlayer))
+	CPlayer* pKillerPlayer = nullptr;
+	if(Killer >=0 && Killer < MAX_CLIENTS)
 	{
+		pKillerPlayer = GameServer()->m_apPlayers[Killer];
+	}
+
+	if(pKillerPlayer && (pKillerPlayer != m_pPlayer))
+	{
+		pKillerPlayer->IncreaseNumberKills();
+		pKillerCharacter = pKillerPlayer->GetCharacter();
 		// set attacker's face to happy (taunt!)
-		if (pKillerCharacter)
+		if(pKillerCharacter)
 		{
 			pKillerCharacter->m_EmoteType = EMOTE_HAPPY;
 			pKillerCharacter->m_EmoteStop = Server()->Tick() + Server()->TickSpeed();
-		}
-		pKillerPlayer->IncreaseNumberKills();
-	}
+			pKillerCharacter->CheckSuperWeaponAccess();
 
-	if (pKillerCharacter)
-	{
-		pKillerCharacter->CheckSuperWeaponAccess();
+			if(pKillerPlayer->GetClass() == PLAYERCLASS_SNIPER)
+			{
+				GiveWeapon(WEAPON_RIFLE, 1);
+			}
+		}
 	}
 }
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2800,7 +2800,7 @@ void CCharacter::Die(int Killer, int Weapon)
 	}
 /* INFECTION MODIFICATION END *****************************************/
 
-	if (m_pPlayer != pKillerPlayer)
+	if (pKillerPlayer && (pKillerPlayer != m_pPlayer))
 	{
 		// set attacker's face to happy (taunt!)
 		if (pKillerCharacter)

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -394,25 +394,6 @@ void CPlayer::Snap(int SnappingClient)
 	}
 }
 
-void CPlayer::FakeSnap(int SnappingClient)
-{
-	IServer::CClientInfo info;
-	Server()->GetClientInfo(SnappingClient, &info);
-	if (info.m_CustClt)
-		return;
-
-	int id = VANILLA_MAX_CLIENTS - 1;
-
-	CNetObj_ClientInfo *pClientInfo = static_cast<CNetObj_ClientInfo *>(Server()->SnapNewItem(NETOBJTYPE_CLIENTINFO, id, sizeof(CNetObj_ClientInfo)));
-
-	if(!pClientInfo)
-		return;
-
-	StrToInts(&pClientInfo->m_Name0, 4, " ");
-	StrToInts(&pClientInfo->m_Clan0, 3, Server()->ClientClan(m_ClientID));
-	StrToInts(&pClientInfo->m_Skin0, 6, m_TeeInfos.m_SkinName);
-}
-
 void CPlayer::OnDisconnect(int Type, const char *pReason)
 {
 	KillCharacter();

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -28,7 +28,6 @@ public:
 	void Tick();
 	void PostTick();
 	void Snap(int SnappingClient);
-	void FakeSnap(int SnappingClient);
 
 	void OnDirectInput(CNetObj_PlayerInput *NewInput);
 	void OnPredictedInput(CNetObj_PlayerInput *NewInput);


### PR DESCRIPTION
I'm not sure if it is needed, but as long as we have a check for the Killer ID being in range, also check the killer player for existence.

Refactor CCharacter::Die to de-duplicate conditions and improve the code locality.