### PR TITLE
Refactor fun rounds; implement a command for arbitrary fun round

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -309,6 +309,9 @@ public:
 	virtual int IsClassChooserEnabled() = 0;
 	virtual bool GetPlayerClassEnabled(int PlayerClass) const = 0;
 	virtual void SetPlayerClassEnabled(int PlayerClass, bool Enabled) = 0;
+
+	virtual int GetPlayerClassProbability(int PlayerClass) const = 0;
+	virtual void SetPlayerClassProbability(int PlayerClass, int Probability) = 0;
 	
 	virtual bool IsClientLogged(int ClientID) = 0;
 #ifdef CONF_SQL

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -332,8 +332,8 @@ public:
 
 public:
 	virtual class CRoundStatistics* RoundStatistics() = 0;
-	virtual void OnRoundStart() = 0;
-	virtual void OnRoundEnd() = 0;
+	virtual void ResetStatistics() = 0;
+	virtual void SendStatistics() = 0;
 	
 	virtual void SetClientMemory(int ClientID, int Memory, bool Value = true) = 0;
 	virtual void ResetClientMemoryAboutGame(int ClientID) = 0;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -309,6 +309,8 @@ public:
 	virtual int IsClassChooserEnabled() = 0;
 	virtual bool GetPlayerClassEnabled(int PlayerClass) const = 0;
 	virtual void SetPlayerClassEnabled(int PlayerClass, bool Enabled) = 0;
+	virtual int GetMinPlayersForClass(int PlayerClass) const = 0;
+	virtual int GetClassPlayerLimit(int PlayerClass) const = 0;
 
 	virtual int GetPlayerClassProbability(int PlayerClass) const = 0;
 	virtual void SetPlayerClassProbability(int PlayerClass, int Probability) = 0;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -307,6 +307,8 @@ public:
 	virtual void SetClassAvailability(int CID, int n) = 0;
 	
 	virtual int IsClassChooserEnabled() = 0;
+	virtual bool GetPlayerClassEnabled(int PlayerClass) const = 0;
+	virtual void SetPlayerClassEnabled(int PlayerClass, bool Enabled) = 0;
 	
 	virtual bool IsClientLogged(int ClientID) = 0;
 #ifdef CONF_SQL

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3016,6 +3016,77 @@ int CServer::IsClassChooserEnabled()
 	return m_InfClassChooser;
 }
 
+bool CServer::GetPlayerClassEnabled(int PlayerClass) const
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MERCENARY:
+			return g_Config.m_InfEnableMercenary;
+		case PLAYERCLASS_MEDIC:
+			return g_Config.m_InfEnableMedic;
+		case PLAYERCLASS_HERO:
+			return g_Config.m_InfEnableHero;
+		case PLAYERCLASS_ENGINEER:
+			return g_Config.m_InfEnableEngineer;
+		case PLAYERCLASS_SOLDIER:
+			return g_Config.m_InfEnableSoldier;
+		case PLAYERCLASS_NINJA:
+			return g_Config.m_InfEnableNinja;
+		case PLAYERCLASS_SNIPER:
+			return g_Config.m_InfEnableSniper;
+		case PLAYERCLASS_SCIENTIST:
+			return g_Config.m_InfEnableScientist;
+		case PLAYERCLASS_BIOLOGIST:
+			return g_Config.m_InfEnableBiologist;
+		case PLAYERCLASS_LOOPER:
+			return g_Config.m_InfEnableLooper;
+		default:
+			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "WARNING: Invalid GetPlayerClassEnabled() call");
+			return false;
+	}
+}
+
+void CServer::SetPlayerClassEnabled(int PlayerClass, bool Enabled)
+{
+	const int Value = Enabled ? 1 : 0;
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MERCENARY:
+			g_Config.m_InfEnableMercenary = Value;
+			break;
+		case PLAYERCLASS_MEDIC:
+			g_Config.m_InfEnableMedic = Value;
+			break;
+		case PLAYERCLASS_HERO:
+			g_Config.m_InfEnableHero = Value;
+			break;
+		case PLAYERCLASS_ENGINEER:
+			g_Config.m_InfEnableEngineer = Value;
+			break;
+		case PLAYERCLASS_SOLDIER:
+			g_Config.m_InfEnableSoldier = Value;
+			break;
+		case PLAYERCLASS_NINJA:
+			g_Config.m_InfEnableNinja = Value;
+			break;
+		case PLAYERCLASS_SNIPER:
+			g_Config.m_InfEnableSniper = Value;
+			break;
+		case PLAYERCLASS_SCIENTIST:
+			g_Config.m_InfEnableScientist = Value;
+			break;
+		case PLAYERCLASS_BIOLOGIST:
+			g_Config.m_InfEnableBiologist = Value;
+			break;
+		case PLAYERCLASS_LOOPER:
+			g_Config.m_InfEnableLooper = Value;
+			break;
+		default:
+			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "WARNING: Invalid SetPlayerClassEnabled() call");
+			return;
+	}
+}
+
 bool CServer::IsClientLogged(int ClientID)
 {
 	return m_aClients[ClientID].m_UserID >= 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3087,6 +3087,81 @@ void CServer::SetPlayerClassEnabled(int PlayerClass, bool Enabled)
 	}
 }
 
+int CServer::GetPlayerClassProbability(int PlayerClass) const
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_SMOKER:
+			return g_Config.m_InfProbaSmoker;
+		case PLAYERCLASS_BOOMER:
+			return g_Config.m_InfProbaBoomer;
+		case PLAYERCLASS_HUNTER:
+			return g_Config.m_InfProbaHunter;
+		case PLAYERCLASS_BAT:
+			return g_Config.m_InfProbaBat;
+		case PLAYERCLASS_GHOST:
+			return g_Config.m_InfProbaGhost;
+		case PLAYERCLASS_SPIDER:
+			return g_Config.m_InfProbaSpider;
+		case PLAYERCLASS_GHOUL:
+			return g_Config.m_InfProbaGhoul;
+		case PLAYERCLASS_SLUG:
+			return g_Config.m_InfProbaSlug;
+		case PLAYERCLASS_VOODOO:
+			return g_Config.m_InfProbaVoodoo;
+		case PLAYERCLASS_WITCH:
+			return g_Config.m_InfProbaWitch;
+		case PLAYERCLASS_UNDEAD:
+			return g_Config.m_InfProbaUndead;
+		default:
+			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "WARNING: Invalid GetPlayerClassProbability() call");
+			return false;
+	}
+}
+
+void CServer::SetPlayerClassProbability(int PlayerClass, int Probability)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_SMOKER:
+			g_Config.m_InfProbaSmoker = Probability;
+			break;
+		case PLAYERCLASS_BOOMER:
+			g_Config.m_InfProbaBoomer = Probability;
+			break;
+		case PLAYERCLASS_HUNTER:
+			g_Config.m_InfProbaHunter = Probability;
+			break;
+		case PLAYERCLASS_BAT:
+			g_Config.m_InfProbaBat = Probability;
+			break;
+		case PLAYERCLASS_GHOST:
+			g_Config.m_InfProbaGhost = Probability;
+			break;
+		case PLAYERCLASS_SPIDER:
+			g_Config.m_InfProbaSpider = Probability;
+			break;
+		case PLAYERCLASS_GHOUL:
+			g_Config.m_InfProbaGhoul = Probability;
+			break;
+		case PLAYERCLASS_SLUG:
+			g_Config.m_InfProbaSlug = Probability;
+			break;
+		case PLAYERCLASS_VOODOO:
+			g_Config.m_InfProbaVoodoo = Probability;
+			break;
+		case PLAYERCLASS_WITCH:
+			g_Config.m_InfProbaWitch = Probability;
+			break;
+		case PLAYERCLASS_UNDEAD:
+			g_Config.m_InfProbaUndead = Probability;
+			break;
+		default:
+			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "WARNING: Invalid SetPlayerClassProbability() call");
+			return;
+	}
+}
+
 bool CServer::IsClientLogged(int ClientID)
 {
 	return m_aClients[ClientID].m_UserID >= 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4523,7 +4523,7 @@ public:
 };
 #endif
 
-void CServer::OnRoundEnd()
+void CServer::SendStatistics()
 {
 #ifdef CONF_SQL
 	// skip some maps that are not very fair
@@ -4555,7 +4555,7 @@ void CServer::OnRoundEnd()
 #endif
 }
 
-void CServer::OnRoundStart()
+void CServer::ResetStatistics()
 {
 	RoundStatistics()->Reset();
 }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4526,15 +4526,6 @@ public:
 void CServer::SendStatistics()
 {
 #ifdef CONF_SQL
-	// skip some maps that are not very fair
-	if (str_comp(m_aCurrentMap, "infc_toilet") == 0) {
-		return;
-	}
-
-	if (GetActivePlayerCount() < 4) {
-		return;
-	}
-
 	//Send round statistics
 	CSqlJob* pRoundJob = new CSqlJob_Server_SendRoundStatistics(this, RoundStatistics(), m_aCurrentMap);
 	pRoundJob->Start();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3087,6 +3087,30 @@ void CServer::SetPlayerClassEnabled(int PlayerClass, bool Enabled)
 	}
 }
 
+int CServer::GetMinPlayersForClass(int PlayerClass) const
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_ENGINEER:
+			return g_Config.m_InfMinPlayersForEngineer;
+		default:
+			return 0;
+	}
+}
+
+int CServer::GetClassPlayerLimit(int PlayerClass) const
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MEDIC:
+			return g_Config.m_InfMedicLimit;
+		case PLAYERCLASS_HERO:
+			return g_Config.m_InfHeroLimit;
+		default:
+			return g_Config.m_SvMaxClients;
+	}
+}
+
 int CServer::GetPlayerClassProbability(int PlayerClass) const
 {
 	switch (PlayerClass)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -400,8 +400,8 @@ public:
 	void AddGameServerCmd(CGameServerCmd* pCmd);
 	
 	virtual CRoundStatistics* RoundStatistics() { return &m_RoundStatistics; }
-	virtual void OnRoundStart();
-	virtual void OnRoundEnd();
+	virtual void ResetStatistics();
+	virtual void SendStatistics();
 	
 	virtual void SetClientMemory(int ClientID, int Memory, bool Value = true);
 	virtual void ResetClientMemoryAboutGame(int ClientID);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -346,6 +346,8 @@ public:
 	virtual int IsClassChooserEnabled();
 	bool GetPlayerClassEnabled(int PlayerClass) const override;
 	void SetPlayerClassEnabled(int PlayerClass, bool Enabled) override;
+	int GetMinPlayersForClass(int PlayerClass) const override;
+	int GetClassPlayerLimit(int PlayerClass) const override;
 	int GetPlayerClassProbability(int PlayerClass) const override;
 	void SetPlayerClassProbability(int PlayerClass, int Probability) override;
 	virtual bool IsClientLogged(int ClientID);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -344,6 +344,8 @@ public:
 	virtual int GetClientNbRound(int ClientID);
 	
 	virtual int IsClassChooserEnabled();
+	bool GetPlayerClassEnabled(int PlayerClass) const override;
+	void SetPlayerClassEnabled(int PlayerClass, bool Enabled) override;
 	virtual bool IsClientLogged(int ClientID);
 #ifdef CONF_SQL
 	virtual void Login(int ClientID, const char* pUsername, const char* pPassword);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -346,6 +346,8 @@ public:
 	virtual int IsClassChooserEnabled();
 	bool GetPlayerClassEnabled(int PlayerClass) const override;
 	void SetPlayerClassEnabled(int PlayerClass, bool Enabled) override;
+	int GetPlayerClassProbability(int PlayerClass) const override;
+	void SetPlayerClassProbability(int PlayerClass, int Probability) override;
 	virtual bool IsClientLogged(int ClientID);
 #ifdef CONF_SQL
 	virtual void Login(int ClientID, const char* pUsername, const char* pPassword);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -121,6 +121,7 @@ MACRO_CONFIG_INT(InfEnableMedic, inf_enable_medic, 1, 0, 1, CFGFLAG_SERVER, "Mak
 MACRO_CONFIG_INT(InfEnableHero, inf_enable_hero, 1, 0, 1, CFGFLAG_SERVER, "Makes the hero class available")
 
 MACRO_CONFIG_INT(InfMinPlayersForEngineer, inf_min_players_for_engineer, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of players that are needed to enable Engineer class")
+MACRO_CONFIG_INT(InfProbaSpawnNearWitch, inf_proba_spawn_near_witch, 66, 0, 100, CFGFLAG_SERVER, "Probability for an infected to spawn near a witch")
 
 MACRO_CONFIG_INT(InfHeroFlagIndicator, inf_hero_flag_indicator, 1, 0, 1, CFGFLAG_SERVER, "Shows the heros in which direction the next flag is")
 MACRO_CONFIG_INT(InfHeroFlagIndicatorTime, inf_hero_flag_indicator_time, 3, 0, 1000, CFGFLAG_SERVER, "How many seconds the hero has to stand still until the indicator is shown")

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -8,6 +8,7 @@
 #include <engine/server/mapconverter.h>
 #include <engine/server/roundstatistics.h>
 #include <game/server/gamecontext.h>
+#include <game/server/gamemodes/mod.h>
 #include <game/mapitems.h>
 #include <iostream>
 
@@ -3345,134 +3346,74 @@ void CCharacter::GiveNinjaBuf()
 
 void CCharacter::ClassSpawnAttributes()
 {
-	switch(GetClass())
+	RemoveAllGun();
+	m_Health = 10;
+
+	const int PlayerClass = GetClass();
+	const bool isHuman = PlayerClass < END_HUMANCLASS; // PLAYERCLASS_NONE is also a human (not infected) class
+	if (isHuman)
+	{
+		m_pPlayer->m_InfectionTick = -1;
+	}
+	else
+	{
+		m_Armor = 0;
+	}
+
+	switch(PlayerClass)
 	{
 		case PLAYERCLASS_ENGINEER:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_RIFLE, -1);
 			m_ActiveWeapon = WEAPON_RIFLE;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_ENGINEER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_ENGINEER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "engineer", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_ENGINEER] = true;
-			}
 			break;
 		case PLAYERCLASS_SOLDIER:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_GRENADE, -1);
 			m_ActiveWeapon = WEAPON_GRENADE;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_SOLDIER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_SOLDIER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "soldier", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_SOLDIER] = true;
-			}
 			break;
 		case PLAYERCLASS_MERCENARY:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GRENADE, -1);
 			GiveWeapon(WEAPON_GUN, -1);
 			m_ActiveWeapon = WEAPON_GUN;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_MERCENARY);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_MERCENARY))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "mercenary", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_MERCENARY] = true;
-			}
 			break;
 		case PLAYERCLASS_SNIPER:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_RIFLE, -1);
 			m_ActiveWeapon = WEAPON_RIFLE;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_SNIPER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_SNIPER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "sniper", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_SNIPER] = true;
-			}
 			break;
 		case PLAYERCLASS_SCIENTIST:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_RIFLE, -1);
 			GiveWeapon(WEAPON_GRENADE, -1);
 			m_ActiveWeapon = WEAPON_GRENADE;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_SCIENTIST);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_SCIENTIST))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "scientist", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_SCIENTIST] = true;
-			}
 			break;
 		case PLAYERCLASS_BIOLOGIST:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_RIFLE, -1);
 			GiveWeapon(WEAPON_SHOTGUN, -1);
 			m_ActiveWeapon = WEAPON_SHOTGUN;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_BIOLOGIST);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_BIOLOGIST))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "biologist", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_BIOLOGIST] = true;
-			}
 			break;
 		case PLAYERCLASS_LOOPER:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_RIFLE, -1);
 			GiveWeapon(WEAPON_GRENADE, -1);
 			m_ActiveWeapon = WEAPON_RIFLE;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_LOOPER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_LOOPER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "looper", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_LOOPER] = true;
-			}
 			break;
-	
 		case PLAYERCLASS_MEDIC:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			GiveWeapon(WEAPON_GUN, -1);
@@ -3480,18 +3421,8 @@ void CCharacter::ClassSpawnAttributes()
 			GiveWeapon(WEAPON_GRENADE, -1);
 			GiveWeapon(WEAPON_RIFLE, -1);
 			m_ActiveWeapon = WEAPON_SHOTGUN;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_MEDIC);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_MEDIC))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "medic", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_MEDIC] = true;
-			}
 			break;
 		case PLAYERCLASS_HERO:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = false;
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_SHOTGUN, -1);
@@ -3499,202 +3430,88 @@ void CCharacter::ClassSpawnAttributes()
 			GiveWeapon(WEAPON_GRENADE, -1);
 			m_pHeroFlag = nullptr;
 			m_ActiveWeapon = WEAPON_GRENADE;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_HERO);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_HERO))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "hero", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_HERO] = true;
-			}
 			break;
 		case PLAYERCLASS_NINJA:
-			RemoveAllGun();
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_GUN, -1);
 			GiveWeapon(WEAPON_GRENADE, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_NINJA);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_NINJA))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "ninja", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_NINJA] = true;
-			}
-			break;
+
 		case PLAYERCLASS_NONE:
-			m_pPlayer->m_InfectionTick = -1;
-			m_Health = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
 			break;
+
 		case PLAYERCLASS_SMOKER:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_SMOKER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_SMOKER))
-			{   
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "smoker", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_SMOKER] = true;
-			}
 			break;
 		case PLAYERCLASS_BOOMER:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_BOOMER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_BOOMER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "boomer", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_BOOMER] = true;
-			}
 			break;
 		case PLAYERCLASS_HUNTER:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_HUNTER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_HUNTER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "hunter", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_HUNTER] = true;
-			}
 			break;
 		case PLAYERCLASS_BAT:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_BAT);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_BAT))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "bat", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_BAT] = true;
-			}
 			break;
 		case PLAYERCLASS_GHOST:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_GHOST);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_GHOST))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "ghost", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_GHOST] = true;
-			}
 			break;
 		case PLAYERCLASS_SPIDER:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_SPIDER);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_SPIDER))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "spider", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_SPIDER] = true;
-			}
 			break;
 		case PLAYERCLASS_VOODOO:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_VOODOO);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_VOODOO))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "voodoo", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_VOODOO] = true;
-			}
 			break;
 		case PLAYERCLASS_GHOUL:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_GHOUL);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_GHOUL))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "ghoul", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_GHOUL] = true;
-			}
 			break;
 		case PLAYERCLASS_SLUG:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_SLUG);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_SLUG))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "slug", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_SLUG] = true;
-			}
 			break;
 		case PLAYERCLASS_UNDEAD:
-			m_Health = 10;
-			m_Armor = 0;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
-			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_UNDEAD);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_UNDEAD))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "undead", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_HUNTER] = true;
-			}
 			break;
 		case PLAYERCLASS_WITCH:
-			m_Health = 10;
+			// Override armor settings
 			m_Armor = 10;
-			RemoveAllGun();
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;
 			
-			GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PLAYERCLASS_WITCH);
-			if(!m_pPlayer->IsKnownClass(PLAYERCLASS_WITCH))
-			{
-				GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", "witch", NULL);
-				m_pPlayer->m_knownClass[PLAYERCLASS_WITCH] = true;
-			}
 			break;
+	}
+
+	if (PlayerClass != PLAYERCLASS_NONE)
+	{
+		GameServer()->SendBroadcast_ClassIntro(m_pPlayer->GetCID(), PlayerClass);
+		if(!m_pPlayer->IsKnownClass(PlayerClass))
+		{
+			const char *className = CGameControllerMOD::GetClassName(PlayerClass);
+			GameServer()->SendChatTarget_Localization(m_pPlayer->GetCID(), CHATCATEGORY_DEFAULT, _("Type “/help {str:ClassName}” for more information about your class"), "ClassName", className, NULL);
+			m_pPlayer->m_knownClass[PlayerClass] = true;
+		}
 	}
 }
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -3494,8 +3494,6 @@ void CCharacter::ClassSpawnAttributes()
 			m_ActiveWeapon = WEAPON_HAMMER;
 			break;
 		case PLAYERCLASS_WITCH:
-			// Override armor settings
-			m_Armor = 10;
 			m_aWeapons[WEAPON_HAMMER].m_Got = true;
 			GiveWeapon(WEAPON_HAMMER, -1);
 			m_ActiveWeapon = WEAPON_HAMMER;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2703,15 +2703,15 @@ bool CGameContext::ConStartFunRound(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	static const FunRoundSettings PossbleSettings[] = {
-		{ PLAYERCLASS_GHOUL, PLAYERCLASS_NINJA, "Ghouls vs Ninjas" },
-		{ PLAYERCLASS_GHOST, PLAYERCLASS_SNIPER, "Ghosts vs Snipers" },
-		{ PLAYERCLASS_GHOUL, PLAYERCLASS_HERO, "Ghouls vs Heroes" },
-		{ PLAYERCLASS_BAT, PLAYERCLASS_MERCENARY, "Bats vs Mercenaries" },
-		{ PLAYERCLASS_BAT, PLAYERCLASS_NINJA, "Bats vs Ninjas" },
-		{ PLAYERCLASS_GHOUL, PLAYERCLASS_MEDIC, "Ghouls vs Medics" },
-		{ PLAYERCLASS_BOOMER, PLAYERCLASS_NINJA, "Boomers vs Ninjas" },
-		{ PLAYERCLASS_GHOUL, PLAYERCLASS_SOLDIER, "Ghouls vs Soldiers" },
-		{ PLAYERCLASS_VOODOO, PLAYERCLASS_ENGINEER, "Voodoos vs Engineers" },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_NINJA },
+		{ PLAYERCLASS_GHOST, PLAYERCLASS_SNIPER },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_HERO },
+		{ PLAYERCLASS_BAT, PLAYERCLASS_MERCENARY },
+		{ PLAYERCLASS_BAT, PLAYERCLASS_NINJA },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_MEDIC },
+		{ PLAYERCLASS_BOOMER, PLAYERCLASS_NINJA },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_SOLDIER },
+		{ PLAYERCLASS_VOODOO, PLAYERCLASS_ENGINEER },
 	};
 
 	const int type = random_int(0, sizeof(PossbleSettings) / sizeof(PossbleSettings[0]) - 1);
@@ -2786,7 +2786,10 @@ bool CGameContext::StartFunRound(const FunRoundSettings &Settings)
 
 	Server()->SetPlayerClassEnabled(Settings.HumanClass, true);
 	Server()->SetPlayerClassProbability(Settings.InfectedClass, 100);
-	str_format(aBuf, sizeof(aBuf), "%s! %s%s", title, Settings.RoundName, random_phrase);
+	const char *HumanClassText = CGameControllerMOD::GetClassPluralDisplayName(Settings.HumanClass);
+	const char *InfectedClassText = CGameControllerMOD::GetClassPluralDisplayName(Settings.InfectedClass);
+
+	str_format(aBuf, sizeof(aBuf), "%s! %s vs %s%s", title, InfectedClassText, HumanClassText, random_phrase);
 
 	m_pController->StartRound();
 	CreateSoundGlobal(SOUND_CTF_CAPTURE);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2719,6 +2719,40 @@ bool CGameContext::ConStartFunRound(IConsole::IResult *pResult, void *pUserData)
 	return pSelf->StartFunRound(Settings);
 }
 
+bool CGameContext::ConStartSpecialFunRound(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	FunRoundSettings Settings;
+
+	for (int argN = 0; argN < pResult->NumArguments(); ++argN)
+	{
+		const char *argument = pResult->GetString(argN);
+		for (int PlayerClass = 0; PlayerClass < NB_PLAYERCLASS; ++PlayerClass)
+		{
+			if (str_comp(argument, CGameControllerMOD::GetClassPluralName(PlayerClass)) == 0)
+			{
+				if ((PlayerClass > START_HUMANCLASS) && (PlayerClass < END_HUMANCLASS))
+				{
+					Settings.HumanClass = PlayerClass;
+					break;
+				}
+				if ((PlayerClass > START_INFECTEDCLASS) && (PlayerClass < END_INFECTEDCLASS))
+				{
+					Settings.InfectedClass = PlayerClass;
+					break;
+				}
+			}
+		}
+	}
+
+	if (!Settings.HumanClass || !Settings.InfectedClass)
+	{
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "invalid special fun round configuration");
+		return false;
+	}
+	return pSelf->StartFunRound(Settings);
+}
+
 bool CGameContext::StartFunRound(const FunRoundSettings &Settings)
 {
 	const char* title = g_Config.m_FunRoundTitle;
@@ -4117,6 +4151,7 @@ void CGameContext::OnConsoleInit()
 	Console()->Register("clear_votes", "", CFGFLAG_SERVER, ConClearVotes, this, "Clears the voting options");
 	Console()->Register("vote", "r", CFGFLAG_SERVER, ConVote, this, "Force a vote to yes/no");
 	Console()->Register("start_fun_round", "", CFGFLAG_SERVER, ConStartFunRound, this, "Start fun round");
+	Console()->Register("start_special_fun_round", "sss", CFGFLAG_SERVER, ConStartSpecialFunRound, this, "Start fun round");
 	
 /* INFECTION MODIFICATION START ***************************************/
 	Console()->Register("inf_set_class", "is", CFGFLAG_SERVER, ConSetClass, this, "Set the class of a player");

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2875,46 +2875,28 @@ bool CGameContext::ConSetClass(IConsole::IResult *pResult, void *pUserData)
 	if(!pPlayer)
 		return true;
 
-	if(str_comp(pClassName, "engineer") == 0) pPlayer->SetClass(PLAYERCLASS_ENGINEER);
-	else if(str_comp(pClassName, "soldier") == 0) pPlayer->SetClass(PLAYERCLASS_SOLDIER);
-	else if(str_comp(pClassName, "scientist") == 0) pPlayer->SetClass(PLAYERCLASS_SCIENTIST);
-	else if(str_comp(pClassName, "biologist") == 0) pPlayer->SetClass(PLAYERCLASS_BIOLOGIST);
-	else if(str_comp(pClassName, "looper") == 0) pPlayer->SetClass(PLAYERCLASS_LOOPER);
-	else if(str_comp(pClassName, "medic") == 0) pPlayer->SetClass(PLAYERCLASS_MEDIC);
-	else if(str_comp(pClassName, "hero") == 0) pPlayer->SetClass(PLAYERCLASS_HERO);
-	else if(str_comp(pClassName, "ninja") == 0) pPlayer->SetClass(PLAYERCLASS_NINJA);
-	else if(str_comp(pClassName, "mercenary") == 0) pPlayer->SetClass(PLAYERCLASS_MERCENARY);
-	else if(str_comp(pClassName, "sniper") == 0) pPlayer->SetClass(PLAYERCLASS_SNIPER);
-	else if(str_comp(pClassName, "smoker") == 0) pPlayer->SetClass(PLAYERCLASS_SMOKER);
-	else if(str_comp(pClassName, "hunter") == 0) pPlayer->SetClass(PLAYERCLASS_HUNTER);
-	else if(str_comp(pClassName, "bat") == 0) pPlayer->SetClass(PLAYERCLASS_BAT);
-	else if(str_comp(pClassName, "boomer") == 0) pPlayer->SetClass(PLAYERCLASS_BOOMER);
-	else if(str_comp(pClassName, "ghost") == 0) pPlayer->SetClass(PLAYERCLASS_GHOST);
-	else if(str_comp(pClassName, "spider") == 0) pPlayer->SetClass(PLAYERCLASS_SPIDER);
-	else if(str_comp(pClassName, "ghoul") == 0) pPlayer->SetClass(PLAYERCLASS_GHOUL);
-	else if(str_comp(pClassName, "slug") == 0) pPlayer->SetClass(PLAYERCLASS_SLUG);
-	else if(str_comp(pClassName, "voodoo") == 0) pPlayer->SetClass(PLAYERCLASS_VOODOO);
-	else if(str_comp(pClassName, "undead") == 0) pPlayer->SetClass(PLAYERCLASS_UNDEAD);
-	else if(str_comp(pClassName, "witch") == 0) pPlayer->SetClass(PLAYERCLASS_WITCH);
-	else if(str_comp(pClassName, "none") == 0)
+	for (int PlayerClass = PLAYERCLASS_NONE; PlayerClass < NB_PLAYERCLASS; ++PlayerClass)
 	{
-		pPlayer->SetClass(PLAYERCLASS_NONE);
-		CCharacter* pChar = pPlayer->GetCharacter();
-		if(pChar)
+		if (str_comp(pClassName, CGameControllerMOD::GetClassName(PlayerClass)) != 0)
+			continue;
+
+		pPlayer->SetClass(PlayerClass);
+		if (PlayerClass == PLAYERCLASS_NONE)
 		{
-			pChar->OpenClassChooser();
+			CCharacter* pChar = pPlayer->GetCharacter();
+			if(pChar)
+			{
+				pChar->OpenClassChooser();
+			}
 		}
-	}
-	else
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "inf_set_class", "Unknown class");
+		char aBuf[256];
+		str_format(aBuf, sizeof(aBuf), "The admin change the class of %s to %s", pSelf->Server()->ClientName(PlayerID), pClassName);
+		pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+
 		return true;
 	}
-	
-	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "The admin change the class of %s to %s", pSelf->Server()->ClientName(PlayerID), pClassName);
-	pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
-	
+
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "inf_set_class", "Unknown class");
 	return true;
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2771,54 +2771,24 @@ bool CGameContext::ConStartFunRound(IConsole::IResult *pResult, void *pUserData)
 	if (g_Config.m_SvTimelimit > g_Config.m_FunRoundDuration)
 		g_Config.m_SvTimelimit = g_Config.m_FunRoundDuration;
 
-	int type = random_int(0, 8);
-	switch (type) { // todo: generalize and shrink, or remove and make something configurable
-		case 0:
-			g_Config.m_InfProbaGhoul = 100;
-			g_Config.m_InfEnableNinja = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Ghouls vs Ninjas%s", title, random_phrase);
-			break;
-		case 1:
-			g_Config.m_InfProbaGhost = 100;
-			g_Config.m_InfEnableSniper = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Ghosts vs Snipers%s", title, random_phrase);
-			break;
-		case 2:
-			g_Config.m_InfProbaGhoul = 100;
-			g_Config.m_InfEnableHero = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Ghouls vs Heroes%s", title, random_phrase);
-			break;
-		case 3:
-			g_Config.m_InfProbaBat = 100;
-			g_Config.m_InfEnableMercenary = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Bats vs Mercenaries%s", title, random_phrase);
-			break;
-		case 4:;
-			g_Config.m_InfProbaBat = 100;
-			g_Config.m_InfEnableNinja = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Bats vs Ninjas%s", title, random_phrase);
-			break;
-		case 5:
-			g_Config.m_InfProbaGhoul = 100;
-			g_Config.m_InfEnableMedic = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Ghouls vs Medics%s", title, random_phrase);
-			break;
-		case 6:
-			g_Config.m_InfProbaBoomer = 100;
-			g_Config.m_InfEnableNinja = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Boomers vs Ninjas%s", title, random_phrase);
-			break;
-		case 7:
-			g_Config.m_InfProbaGhoul = 100;
-			g_Config.m_InfEnableSoldier = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Ghouls vs Soldiers%s", title, random_phrase);
-			break;
-		case 8:
-			g_Config.m_InfProbaVoodoo = 100;
-			g_Config.m_InfEnableEngineer = 1;
-			str_format(aBuf, sizeof(aBuf), "%s! Voodoos vs Engineers%s", title, random_phrase);
-			break;
-	}
+	static const FunRoundSettings PossbleSettings[] = {
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_NINJA, "Ghouls vs Ninjas" },
+		{ PLAYERCLASS_GHOST, PLAYERCLASS_SNIPER, "Ghosts vs Snipers" },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_HERO, "Ghouls vs Heroes" },
+		{ PLAYERCLASS_BAT, PLAYERCLASS_MERCENARY, "Bats vs Mercenaries" },
+		{ PLAYERCLASS_BAT, PLAYERCLASS_NINJA, "Bats vs Ninjas" },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_MEDIC, "Ghouls vs Medics" },
+		{ PLAYERCLASS_BOOMER, PLAYERCLASS_NINJA, "Boomers vs Ninjas" },
+		{ PLAYERCLASS_GHOUL, PLAYERCLASS_SOLDIER, "Ghouls vs Soldiers" },
+		{ PLAYERCLASS_VOODOO, PLAYERCLASS_ENGINEER, "Voodoos vs Engineers" },
+	};
+
+	const int type = random_int(0, sizeof(PossbleSettings) / sizeof(PossbleSettings[0]) - 1);
+	const FunRoundSettings &Settings = PossbleSettings[type];
+	Server()->SetPlayerClassEnabled(Settings.HumanClass, true);
+	Server()->SetPlayerClassProbability(Settings.InfectedClass, 100);
+	str_format(aBuf, sizeof(aBuf), "%s! %s%s", title, Settings.RoundName, random_phrase);
+
 	pSelf->m_pController->StartRound();
 	pSelf->CreateSoundGlobal(SOUND_CTF_CAPTURE);
 	pSelf->SendChatTarget(-1, aBuf);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -103,6 +103,7 @@ class CGameContext : public IGameServer
 	static bool ConClearVotes(IConsole::IResult *pResult, void *pUserData);
 	static bool ConVote(IConsole::IResult *pResult, void *pUserData);
 	static bool ConStartFunRound(IConsole::IResult *pResult, void *pUserData);
+	static bool ConStartSpecialFunRound(IConsole::IResult *pResult, void *pUserData);
 	static bool ConchainSpecialMotdupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	CGameContext(int Resetting);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -57,6 +57,8 @@ typedef unsigned __int64 uint64_t;
 #define BROADCAST_DURATION_REALTIME (0)
 #define BROADCAST_DURATION_GAMEANNOUNCE (Server()->TickSpeed()*2)
 
+struct FunRoundSettings;
+
 enum
 {
 	BROADCAST_PRIORITY_LOWEST=0,
@@ -141,6 +143,7 @@ public:
 	std::vector<int> m_WitchCallers;
 
 	// InfClassR fun round
+	bool StartFunRound(const FunRoundSettings &Settings);
 	void EndFunRound();
 	bool m_FunRound;
 	int m_FunRoundsPassed;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -62,6 +62,20 @@ bool IGameController::PreSpawn(CPlayer* pPlayer, vec2 *pOutPos)
 	
 	return false;
 }
+
+void IGameController::MaybeSendStatistics()
+{
+	// skip some maps that are not very fair
+	if (str_comp(g_Config.m_SvMap, "infc_toilet") == 0) {
+		return;
+	}
+
+	if (Server()->GetActivePlayerCount() < 4) {
+		return;
+	}
+
+	Server()->SendStatistics();
+}
 /* INFECTION MODIFICATION END *****************************************/
 
 
@@ -91,8 +105,7 @@ void IGameController::EndRound()
 	m_GameOverTick = Server()->Tick();
 	m_SuddenDeath = 0;
 	
-	//Send score to the server
-	Server()->SendStatistics();
+	MaybeSendStatistics();
 
 	if (GameServer()->m_FunRound)
 		GameServer()->EndFunRound();

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -74,6 +74,9 @@ void IGameController::MaybeSendStatistics()
 		return;
 	}
 
+	if (GameServer()->m_FunRound)
+		return;
+
 	Server()->SendStatistics();
 }
 /* INFECTION MODIFICATION END *****************************************/

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -92,7 +92,7 @@ void IGameController::EndRound()
 	m_SuddenDeath = 0;
 	
 	//Send score to the server
-	Server()->OnRoundEnd();
+	Server()->SendStatistics();
 
 	if (GameServer()->m_FunRound)
 		GameServer()->EndFunRound();
@@ -136,7 +136,7 @@ void IGameController::StartRound()
 {
 	ResetGame();
 	
-	Server()->OnRoundStart();
+	Server()->ResetStatistics();
 	GameServer()->OnStartRound();
 	
 /* INFECTION MODIFICATION START ***************************************/

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -155,6 +155,7 @@ public:
 	virtual void OnPlayerInfected(CPlayer* pPlayer, CPlayer* pInfectiousPlayer) = 0;
 	virtual bool IsInfectionStarted() = 0;
 	
+	void MaybeSendStatistics();
 	int GetRoundId() { return m_RoundId; }
 /* INFECTION MODIFICATION END *****************************************/
 

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -1097,6 +1097,11 @@ int CGameControllerMOD::ChooseInfectedClass(const CPlayer *pPlayer) const
 	{
 		double &ClassProbability = Probability[PlayerClass - START_INFECTEDCLASS - 1];
 		ClassProbability = Server()->GetClassAvailability(PlayerClass) ? Server()->GetPlayerClassProbability(PlayerClass) : 0;
+		if (GameServer()->m_FunRound)
+		{
+			// We care only about the class enablement
+			continue;
+		}
 
 		switch(PlayerClass)
 		{

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -135,6 +135,34 @@ void CGameControllerMOD::ResetFinalExplosion()
 	}
 }
 
+bool CGameControllerMOD::IsDefenderClass(int PlayerClass)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_ENGINEER:
+		case PLAYERCLASS_SOLDIER:
+		case PLAYERCLASS_SCIENTIST:
+		case PLAYERCLASS_BIOLOGIST:
+		case PLAYERCLASS_LOOPER:
+			return true;
+		default:
+			return false;
+	}
+}
+
+bool CGameControllerMOD::IsSupportClass(int PlayerClass)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_NINJA:
+		case PLAYERCLASS_MERCENARY:
+		case PLAYERCLASS_SNIPER:
+			return true;
+		default:
+			return false;
+	}
+}
+
 void CGameControllerMOD::EndRound()
 {	
 	m_InfectedStarted = false;

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -828,6 +828,11 @@ int CGameControllerMOD::ChooseHumanClass(const CPlayer *pPlayer) const
 	{
 		double &ClassProbability = Probability[PlayerClass - START_HUMANCLASS - 1];
 		ClassProbability = Server()->GetPlayerClassEnabled(PlayerClass) ? 1.0f : 0.0f;
+		if (GameServer()->m_FunRound)
+		{
+			// We care only about the class enablement
+			continue;
+		}
 
 		if (IsDefenderClass(PlayerClass) && (nbDefender >= g_Config.m_InfDefenderLimit))
 			ClassProbability = 0.0f;

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -164,6 +164,218 @@ bool CGameControllerMOD::IsSupportClass(int PlayerClass)
 	}
 }
 
+const char *CGameControllerMOD::GetClassName(int PlayerClass)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MERCENARY:
+			return "mercenary";
+		case PLAYERCLASS_MEDIC:
+			return "medic";
+		case PLAYERCLASS_HERO:
+			return "hero";
+		case PLAYERCLASS_ENGINEER:
+			return "engineer";
+		case PLAYERCLASS_SOLDIER:
+			return "soldier";
+		case PLAYERCLASS_NINJA:
+			return "ninja";
+		case PLAYERCLASS_SNIPER:
+			return "sniper";
+		case PLAYERCLASS_SCIENTIST:
+			return "scientist";
+		case PLAYERCLASS_BIOLOGIST:
+			return "biologist";
+		case PLAYERCLASS_LOOPER:
+			return "looper";
+
+		case PLAYERCLASS_SMOKER:
+			return "smoker";
+		case PLAYERCLASS_BOOMER:
+			return "boomer";
+		case PLAYERCLASS_HUNTER:
+			return "hunter";
+		case PLAYERCLASS_BAT:
+			return "bat";
+		case PLAYERCLASS_GHOST:
+			return "ghost";
+		case PLAYERCLASS_SPIDER:
+			return "spider";
+		case PLAYERCLASS_GHOUL:
+			return "ghoul";
+		case PLAYERCLASS_SLUG:
+			return "slug";
+		case PLAYERCLASS_VOODOO:
+			return "voodoo";
+		case PLAYERCLASS_WITCH:
+			return "witch";
+		case PLAYERCLASS_UNDEAD:
+			return "undead";
+
+		default:
+			return "unknown";
+	}
+}
+
+const char *CGameControllerMOD::GetClassPluralName(int PlayerClass)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MERCENARY:
+			return "mercenaries";
+		case PLAYERCLASS_MEDIC:
+			return "medics";
+		case PLAYERCLASS_HERO:
+			return "heroes";
+		case PLAYERCLASS_ENGINEER:
+			return "engineers";
+		case PLAYERCLASS_SOLDIER:
+			return "soldiers";
+		case PLAYERCLASS_NINJA:
+			return "ninjas";
+		case PLAYERCLASS_SNIPER:
+			return "snipers";
+		case PLAYERCLASS_SCIENTIST:
+			return "scientists";
+		case PLAYERCLASS_BIOLOGIST:
+			return "biologists";
+		case PLAYERCLASS_LOOPER:
+			return "loopers";
+
+		case PLAYERCLASS_SMOKER:
+			return "smokers";
+		case PLAYERCLASS_BOOMER:
+			return "boomers";
+		case PLAYERCLASS_HUNTER:
+			return "hunters";
+		case PLAYERCLASS_BAT:
+			return "bats";
+		case PLAYERCLASS_GHOST:
+			return "ghosts";
+		case PLAYERCLASS_SPIDER:
+			return "spiders";
+		case PLAYERCLASS_GHOUL:
+			return "ghouls";
+		case PLAYERCLASS_SLUG:
+			return "slugs";
+		case PLAYERCLASS_VOODOO:
+			return "voodoos";
+		case PLAYERCLASS_WITCH:
+			return "witches";
+		case PLAYERCLASS_UNDEAD:
+			return "undeads";
+
+		default:
+			return "unknown";
+	}
+}
+
+const char *CGameControllerMOD::GetClassDisplayName(int PlayerClass)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MERCENARY:
+			return "Mercenary";
+		case PLAYERCLASS_MEDIC:
+			return "Medic";
+		case PLAYERCLASS_HERO:
+			return "Hero";
+		case PLAYERCLASS_ENGINEER:
+			return "Engineer";
+		case PLAYERCLASS_SOLDIER:
+			return "Soldier";
+		case PLAYERCLASS_NINJA:
+			return "Ninja";
+		case PLAYERCLASS_SNIPER:
+			return "Sniper";
+		case PLAYERCLASS_SCIENTIST:
+			return "Scientist";
+		case PLAYERCLASS_BIOLOGIST:
+			return "Biologist";
+		case PLAYERCLASS_LOOPER:
+			return "Looper";
+
+		case PLAYERCLASS_SMOKER:
+			return "Smoker";
+		case PLAYERCLASS_BOOMER:
+			return "Boomer";
+		case PLAYERCLASS_HUNTER:
+			return "Hunter";
+		case PLAYERCLASS_BAT:
+			return "Bat";
+		case PLAYERCLASS_GHOST:
+			return "Ghost";
+		case PLAYERCLASS_SPIDER:
+			return "Spider";
+		case PLAYERCLASS_GHOUL:
+			return "Ghoul";
+		case PLAYERCLASS_SLUG:
+			return "Slug";
+		case PLAYERCLASS_VOODOO:
+			return "Voodoo";
+		case PLAYERCLASS_WITCH:
+			return "Witch";
+		case PLAYERCLASS_UNDEAD:
+			return "Undead";
+
+		default:
+			return "unknown";
+	}
+}
+
+const char *CGameControllerMOD::GetClassPluralDisplayName(int PlayerClass)
+{
+	switch (PlayerClass)
+	{
+		case PLAYERCLASS_MERCENARY:
+			return "Mercenaries";
+		case PLAYERCLASS_MEDIC:
+			return "Medics";
+		case PLAYERCLASS_HERO:
+			return "Heroes";
+		case PLAYERCLASS_ENGINEER:
+			return "Engineers";
+		case PLAYERCLASS_SOLDIER:
+			return "Soldiers";
+		case PLAYERCLASS_NINJA:
+			return "Ninjas";
+		case PLAYERCLASS_SNIPER:
+			return "Snipers";
+		case PLAYERCLASS_SCIENTIST:
+			return "Scientists";
+		case PLAYERCLASS_BIOLOGIST:
+			return "Biologists";
+		case PLAYERCLASS_LOOPER:
+			return "Loopers";
+
+		case PLAYERCLASS_SMOKER:
+			return "Smokers";
+		case PLAYERCLASS_BOOMER:
+			return "Boomers";
+		case PLAYERCLASS_HUNTER:
+			return "Hunters";
+		case PLAYERCLASS_BAT:
+			return "Bats";
+		case PLAYERCLASS_GHOST:
+			return "Ghosts";
+		case PLAYERCLASS_SPIDER:
+			return "Spiders";
+		case PLAYERCLASS_GHOUL:
+			return "Ghouls";
+		case PLAYERCLASS_SLUG:
+			return "Slugs";
+		case PLAYERCLASS_VOODOO:
+			return "Voodoos";
+		case PLAYERCLASS_WITCH:
+			return "Witches";
+		case PLAYERCLASS_UNDEAD:
+			return "Undeads";
+
+		default:
+			return "unknown";
+	}
+}
+
 void CGameControllerMOD::EndRound()
 {	
 	m_InfectedStarted = false;

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -968,7 +968,7 @@ bool CGameControllerMOD::PreSpawn(CPlayer* pPlayer, vec2 *pOutPos)
 	if(pPlayer->IsZombie() && m_ExplosionStarted)
 		return false;
 		
-	if(m_InfectedStarted && pPlayer->IsZombie() && random_prob(0.66f))
+	if(m_InfectedStarted && pPlayer->IsZombie() && random_prob(g_Config.m_InfProbaSpawnNearWitch / 100.0f))
 	{
 		CPlayerIterator<PLAYERITER_INGAME> Iter(GameServer()->m_apPlayers);
 		while(Iter.Next())

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -168,6 +168,9 @@ const char *CGameControllerMOD::GetClassName(int PlayerClass)
 {
 	switch (PlayerClass)
 	{
+		case PLAYERCLASS_NONE:
+			return "none";
+
 		case PLAYERCLASS_MERCENARY:
 			return "mercenary";
 		case PLAYERCLASS_MEDIC:

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -10,16 +10,14 @@
 struct FunRoundSettings
 {
 	FunRoundSettings() = default;
-	FunRoundSettings(int Infected, int Human, const char *Name)
+	FunRoundSettings(int Infected, int Human)
 	: InfectedClass(Infected),
-	  HumanClass(Human),
-	  RoundName(Name)
+	  HumanClass(Human)
 	{
 	}
 
 	int InfectedClass = 0;
 	int HumanClass = 0;
-	const char *RoundName = nullptr;
 };
 
 // you can subclass GAMECONTROLLER_CTF, GAMECONTROLLER_TDM etc if you want

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -37,6 +37,9 @@ public:
 	
 	void ResetFinalExplosion();
 	
+	static bool IsDefenderClass(int PlayerClass);
+	static bool IsSupportClass(int PlayerClass);
+
 private:
 	bool IsSpawnable(vec2 Pos, int TeleZoneIndex);
 	void GetPlayerCounter(int ClientException, int& NumHumans, int& NumInfected, int& NumFirstInfected);

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -54,6 +54,10 @@ public:
 	
 	static bool IsDefenderClass(int PlayerClass);
 	static bool IsSupportClass(int PlayerClass);
+	static const char *GetClassName(int PlayerClass);
+	static const char *GetClassPluralName(int PlayerClass);
+	static const char *GetClassDisplayName(int PlayerClass);
+	static const char *GetClassPluralDisplayName(int PlayerClass);
 
 private:
 	bool IsSpawnable(vec2 Pos, int TeleZoneIndex);

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -7,6 +7,21 @@
 #include <game/server/classes.h>
 #include <game/server/entities/hero-flag.h>
 
+struct FunRoundSettings
+{
+	FunRoundSettings() = default;
+	FunRoundSettings(int Infected, int Human, const char *Name)
+	: InfectedClass(Infected),
+	  HumanClass(Human),
+	  RoundName(Name)
+	{
+	}
+
+	int InfectedClass = 0;
+	int HumanClass = 0;
+	const char *RoundName = nullptr;
+};
+
 // you can subclass GAMECONTROLLER_CTF, GAMECONTROLLER_TDM etc if you want
 // todo a modification with their base as well.
 class CGameControllerMOD : public IGameController


### PR DESCRIPTION
- Refactor the fun rounds in a bit more generic way
- Add command 'start_special_fun_round' to run an arbitrary confrontation.
Examples:
  - `start_special_fun_round slugs vs ninjas`
  - `start_special_fun_round voodoos vs scientists`
