### PR TITLE
Cleanup Character on object destruction

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -236,7 +236,8 @@ void CCharacter::Destroy()
 /* INFECTION MODIFICATION START ***************************************/
 	DestroyChildEntities();
 	
-	m_pPlayer->ResetNumberKills();
+	if (m_pPlayer)
+		m_pPlayer->ResetNumberKills();
 	
 	if(m_FlagID >= 0)
 	{
@@ -272,7 +273,8 @@ void CCharacter::Destroy()
 	
 /* INFECTION MODIFICATION END *****************************************/
 
-	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
+	if (m_pPlayer)
+		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
 	m_Alive = false;
 }
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -116,6 +116,11 @@ m_pConsole(pConsole)
 /* INFECTION MODIFICATION END *****************************************/
 }
 
+CCharacter::~CCharacter()
+{
+	Destroy();
+}
+
 bool CCharacter::FindWitchSpawnPosition(vec2& Pos)
 {
 	float Angle = atan2f(m_Input.m_TargetY, m_Input.m_TargetX);//atan2f instead of atan2

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -53,6 +53,7 @@ public:
 	static const int ms_PhysSize = 28;
 
 	CCharacter(CGameWorld *pWorld, IConsole *pConsole);
+	~CCharacter() override;
 
 	virtual void Reset();
 	virtual void Destroy();

--- a/src/game/server/entities/looper-wall.cpp
+++ b/src/game/server/entities/looper-wall.cpp
@@ -17,6 +17,12 @@ CLooperWall::CLooperWall(CGameWorld *pGameWorld, vec2 Pos1, vec2 Pos2, int Owner
 	}
 	else m_Pos2 = Pos2;
 	m_Owner = Owner;
+	m_IDs.set_size(2);
+	for(int i=0; i<2; i++)
+	{
+		m_IDs[i] = Server()->SnapNewID();
+	}
+
 	m_LifeSpan = Server()->TickSpeed()*g_Config.m_InfLooperBarrierLifeSpan;
 	GameWorld()->InsertEntity(this);
 	
@@ -40,6 +46,10 @@ CLooperWall::~CLooperWall()
 	for(int i=0; i<NUM_PARTICLES; i++)
 	{
 		Server()->SnapFreeID(m_ParticleIDs[i]);
+	}
+	for(int i=0; i<2; i++)
+	{
+		Server()->SnapFreeID(m_IDs[i]);
 	}
 }
 

--- a/src/game/server/entities/looper-wall.h
+++ b/src/game/server/entities/looper-wall.h
@@ -26,6 +26,7 @@ public:
 private:
 	vec2 m_Pos2;
 	int m_LifeSpan;
+	array<int> m_IDs;
 	array<int> m_EndPointIDs;
 	const float g_BarrierMaxLength = 400.0;
 	const float g_BarrierRadius = 0.0;

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -19,12 +19,6 @@ CEntity::CEntity(CGameWorld *pGameWorld, int ObjType)
 
 	m_MarkedForDestroy = false;
 	m_ID = Server()->SnapNewID();
-	
-	m_IDs.set_size(2);
-	for(int i=0; i<2; i++)
-	{
-		m_IDs[i] = Server()->SnapNewID();
-	}
 
 	m_pPrevTypeEntity = 0;
 	m_pNextTypeEntity = 0;
@@ -34,18 +28,6 @@ CEntity::~CEntity()
 {
 	GameWorld()->RemoveEntity(this);
 	Server()->SnapFreeID(m_ID);
-	
-	
-	if(m_IDs[0] >= 0)
-	{
-		for(int i=0; i<2; i++) 
-		{
-			Server()->SnapFreeID(m_IDs[i]);
-			m_IDs[i] = -1;
-		}
-		
-	}
-	
 }
 
 int CEntity::NetworkClipped(int SnappingClient)

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -66,7 +66,6 @@ class CEntity
 protected:
 	bool m_MarkedForDestroy;
 	int m_ID;
-	array<int> m_IDs;
 	int m_ObjType;
 public:
 	CEntity(CGameWorld *pGameWorld, int Objtype);


### PR DESCRIPTION
- Call Destroy() to remove allocated SnapIDs.
- CEntity: Move extra SnapIDs allocation to the only relevant subclass — CLooperWall.