### PR TITLE
Add temporary log statements for further investigation

### DIFF
--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -917,7 +917,11 @@ void CGameControllerMOD::DoWincheck()
 		//If no more explosions, game over, decide who win
 		if(!NewExplosion)
 		{
-			if(NumHumans)
+      char aBuf[512];
+      str_format(aBuf, sizeof(aBuf), "EXPLOSIONS FINISHED. HUMAN COUNT: %d", NumHumans);
+      GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+			
+      if(NumHumans)
 			{
 				GameServer()->SendChatTarget_Localization_P(-1, CHATCATEGORY_HUMANS, NumHumans, _P("One human won the round", "{int:NumHumans} humans won the round"), "NumHumans", &NumHumans, NULL);
 
@@ -925,10 +929,14 @@ void CGameControllerMOD::DoWincheck()
 				str_format(aBuf, sizeof(aBuf), "round_end winner='humans' survivors='%d' duration='%d' round='%d of %d' type='%s'", NumHumans, Seconds, m_RoundCount+1, g_Config.m_SvRoundsPerMap, RoundType);
 				GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
-					CPlayerIterator<PLAYERITER_INGAME> Iter(GameServer()->m_apPlayers);
+        CPlayerIterator<PLAYERITER_INGAME> Iter(GameServer()->m_apPlayers);
 				while(Iter.Next())
 				{
-					if(Iter.Player()->IsHuman())
+          char aBuf[512];
+          str_format(aBuf, sizeof(aBuf), "CHECKING IF %s IS HUMAN", Server()->ClientName(Iter.ClientID()));
+          GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+					
+          if(Iter.Player()->IsHuman())
 					{
 						//TAG_SCORE
 						Server()->RoundStatistics()->OnScoreEvent(Iter.ClientID(), SCOREEVENT_HUMAN_SURVIVE, Iter.Player()->GetClass(), Server()->ClientName(Iter.ClientID()), GameServer()->Console());
@@ -937,7 +945,7 @@ void CGameControllerMOD::DoWincheck()
 						Iter.Player()->m_WinAsHuman++;
 
 						GameServer()->SendChatTarget_Localization(Iter.ClientID(), CHATCATEGORY_SCORE, _("You have survived, +5 points"), NULL);
-							char aBuf[256];
+            char aBuf[256];
 						str_format(aBuf, sizeof(aBuf), "survived player='%s'", Server()->ClientName(Iter.ClientID()));
 						GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 						}
@@ -945,6 +953,10 @@ void CGameControllerMOD::DoWincheck()
 			}
 			else
 			{
+        char aBuf[512];
+        str_format(aBuf, sizeof(aBuf), "ZOMBIES WON");
+        GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
 				GameServer()->SendChatTarget_Localization(-1, CHATCATEGORY_INFECTED, _("Infected won the round in {sec:RoundDuration}"), "RoundDuration", &Seconds, NULL);
 			}
 


### PR DESCRIPTION
Currently, when humans survive on the 5th round the expected log statements to display all survivors do not seem to be printed which however is the case for round 1-4

Example:
```
[game]: round_end winner='zombies' survivors='0' duration='35' round='5 of 5' type='witch_portals'
[game]: infc_warehouse_winter
[game]: choose_class player='Mhe|LiSSa ☪' class='0'
[game]: choose_class player='⚜xPace⚜' class='0'
[game]: start round type='InfClassR' teamplay='0' id='1544617505'
```

```
[game]: round_end winner='humans' survivors='8' duration='242' round='5 of 5' type='witch_portals'
[game]: score player='breton' amount='50'
[game]: infc_normandie_2k19
[game]: choose_class player='breton' class='0'
[game]: choose_class player='FakeDeath' class='0'
[game]: choose_class player='HotlineMiami' class='0'
[game]: choose_class player='.' class='0'
[game]: choose_class player='Hugo' class='0'
[game]: choose_class player='V.I.R.U.S.' class='0'
[game]: choose_class player='Yo|omgg' class='0'
[game]: choose_class player='error_io_YKT' class='0'
[game]: choose_class player='Jac0X' class='0'
[game]: choose_class player='Yavl-YKT' class='0'
[game]: choose_class player='DoShik' class='0'
[game]: choose_class player='Manmellon' class='0'
[game]: choose_class player='Wayl' class='0'
[game]: choose_class player='Prokofiev' class='0'
[game]: start round type='InfClassR' teamplay='0' id='2039723618'
```

Intended Behaviour:
```
[game]: round_end winner='humans' survivors='1' duration='302' round='3 of 5' type='witch_portals'
[game]: score player='fup' amount='50'
[game]: survived player='fup'
[game]: choose_class player='TarBer' class='0'
[game]: choose_class player='.planshe' class='0'
[game]: choose_class player='fup' class='0'
[game]: choose_class player='shapii' class='0'
[game]: choose_class player='Yo|omgg' class='0'
[game]: start round type='InfClassR' teamplay='0' id='654887343'
```

```
[game]: round_end winner='humans' survivors='5' duration='243' round='4 of 5' type='witch_portals'
[game]: score player='LibreTee' amount='50'
[game]: survived player='LibreTee'
[game]: score player='error_io_YKT' amount='50'
[game]: survived player='error_io_YKT'
[game]: score player='HT_ranger' amount='50'
[game]: survived player='HT_ranger'
[game]: score player='Yo|omgg' amount='50'
[game]: survived player='Yo|omgg'
[game]: score player='$Boss$' amount='50'
[game]: survived player='$Boss$'
[game]: choose_class player='LibreTee' class='0'
[game]: choose_class player='.' class='0'
[game]: choose_class player='error_io_YKT' class='0'
[game]: choose_class player='Yavl-YKT' class='0'
[game]: choose_class player='HT_ranger' class='0'
[game]: choose_class player='Yo|omgg' class='0'
[game]: choose_class player='Emrldy' class='0'
[game]: choose_class player='$Boss$' class='0'
[game]: choose_class player='reVar' class='0'
[game]: start round type='InfClassR' teamplay='0' id='1914544919'
```
I do not know what is causing the print statement to not be executed on the 5th round,
I still cannot reproduce this locally so I need some further log statements to look into this
on the live server

Expected print statement here: https://github.com/bretonium/my-infclass-server/blob/master/src/game/server/gamemodes/mod.cpp#L925

On a side note: Did anyone notice that players will not get +5 points on the 5th round if they survived I haven't checked myself?