### PR TITLE
Further investigation

### DIFF
--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -938,17 +938,21 @@ void CGameControllerMOD::DoWincheck()
 					
           if(Iter.Player()->IsHuman())
 					{
+						GameServer()->SendChatTarget_Localization(Iter.ClientID(), CHATCATEGORY_SCORE, _("You have survived, +5 points"), NULL);
+            char aBuf[256];
+						str_format(aBuf, sizeof(aBuf), "survived player='%s'", Server()->ClientName(Iter.ClientID()));
+						GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+						
 						//TAG_SCORE
 						Server()->RoundStatistics()->OnScoreEvent(Iter.ClientID(), SCOREEVENT_HUMAN_SURVIVE, Iter.Player()->GetClass(), Server()->ClientName(Iter.ClientID()), GameServer()->Console());
 						Server()->RoundStatistics()->SetPlayerAsWinner(Iter.ClientID());
 						GameServer()->SendScoreSound(Iter.ClientID());
 						Iter.Player()->m_WinAsHuman++;
-
-						GameServer()->SendChatTarget_Localization(Iter.ClientID(), CHATCATEGORY_SCORE, _("You have survived, +5 points"), NULL);
-            char aBuf[256];
-						str_format(aBuf, sizeof(aBuf), "survived player='%s'", Server()->ClientName(Iter.ClientID()));
+					} else {
+						char aBuf[512];
+						str_format(aBuf, sizeof(aBuf), "%s IS NOT A HUMAN", Server()->ClientName(Iter.ClientID()));
 						GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
-						}
+					}
 				}
 			}
 			else


### PR DESCRIPTION
It loops thorugh every player until it finds the first of possibly multiple players that has survived and seems to stop there. 

```
[game]: EXPLOSIONS FINISHED. HUMAN COUNT: 2
[game]: round_end winner='humans' survivors='2' duration='181' round='5 of 5' type='witch_portals'
[game]: CHECKING IF the kek IS HUMAN
[game]: CHECKING IF AmirWizard IS HUMAN
[game]: CHECKING IF semyonixxx IS HUMAN
[game]: CHECKING IF Aria IS HUMAN
[game]: CHECKING IF Two Feet IS HUMAN
[game]: CHECKING IF Hey, fuck you! IS HUMAN
[game]: CHECKING IF CHHC IS HUMAN
[game]: score player='CHHC' amount='50'
[game]: infc_towers
```
```
[game]: EXPLOSIONS FINISHED. HUMAN COUNT: 3
[game]: round_end winner='humans' survivors='3' duration='242' round='5 of 5' type='witch_portals'
[game]: CHECKING IF the kek IS HUMAN
[game]: CHECKING IF AmirWizard IS HUMAN
[game]: CHECKING IF Bill Murray IS HUMAN
[game]: CHECKING IF Aria IS HUMAN
[game]: CHECKING IF breton IS HUMAN
[game]: CHECKING IF jetlee IS HUMAN
[game]: CHECKING IF chalijoongik IS HUMAN
[game]: CHECKING IF Yavl-YKT IS HUMAN
[game]: CHECKING IF sαιηт IS HUMAN
[game]: CHECKING IF coye IS HUMAN
[game]: CHECKING IF Maldito IS HUMAN
[game]: CHECKING IF N|A|N|A IS HUMAN
[game]: CHECKING IF Sakura:3 IS HUMAN
[game]: CHECKING IF RB - Grizzly IS HUMAN
[game]: CHECKING IF B'Bay IS HUMAN
[game]: CHECKING IF Mhe|LiSSa ☪ IS HUMAN
[game]: CHECKING IF Eteextra IS HUMAN
[game]: CHECKING IF nameless tee IS HUMAN
[game]: CHECKING IF Krümel IS HUMAN
[game]: CHECKING IF Ali_RNT IS HUMAN
[game]: score player='Ali_RNT' amount='50'
[game]: infc_normandie_2k19
```
I still cannot find the cause so I need further debug statements + a possible "fix" merged